### PR TITLE
PHPUnit 8 forward compatibility

### DIFF
--- a/tests/Annotation/TemplateTest.php
+++ b/tests/Annotation/TemplateTest.php
@@ -17,12 +17,12 @@ class TemplateTest extends TestCase
      */
     private $listener;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         class_exists(Template::class);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $reader = new AnnotationReader();
         $this->listener = new ControllerListener($reader);

--- a/tests/Controller/TemplateControllerTest.php
+++ b/tests/Controller/TemplateControllerTest.php
@@ -14,7 +14,7 @@ class TemplateControllerTest extends TestCase
      */
     private $controller;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Listener/TemplateListenerTest.php
+++ b/tests/Listener/TemplateListenerTest.php
@@ -18,12 +18,12 @@ class TemplateListenerTest extends TestCase
      */
     private $listener;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         class_exists(Template::class);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $loader = new ArrayLoader([]);
         $twig = new Environment($loader);


### PR DESCRIPTION
This PR adds `void` return types to `setUp` and `setUpBeforeClass` methods, so PHPUnit 8 may be used to run the test suite.